### PR TITLE
WIP add getTemporaryUrl

### DIFF
--- a/src/ElementsAdapter.php
+++ b/src/ElementsAdapter.php
@@ -2,18 +2,36 @@
 
 namespace Biigle\Filesystem;
 
+
 use Biigle\Flysystem\Elements\ElementsAdapter as BaseAdapter;
 
 class ElementsAdapter extends BaseAdapter
 {
     /**
-     * Get the URL for the file at the given path.
+     * Get the temporary URL for the file at the given path.
      *
      * @param  string  $path
+     * @param DateTime $expiration
+     * @param array $options
      * @return string
      */
-    // public function getUrl($path)
-    // {
-    //     //
-    // }
+    public function getTemporaryUrl($path, $expiration, $options)
+    {
+        $id = $this->getMediaFile($path)['bundle'];
+
+        $response = $this->client->post("api/2/media/share", [
+            'json' => [
+                'bundles' => [$id],
+                'expires' => $expiration->format('c'),
+                'link_type' => 'download-proxy',
+                'permissions' => [
+                    'allow_proxy_download' => true,
+                ],
+            ],
+        ]);
+
+        $data = json_decode($response->getBody(), true);
+
+        return $data['full_url'];
+    }
 }


### PR DESCRIPTION
This adds `getTemporaryUrl` but it isn't working yet.

The temporary URL redirects to a download view instead of a direct file download (as described here https://github.com/elements-storage/elements-sdk-python/issues/1#issuecomment-906209763).